### PR TITLE
Relax activesupport dependency for rails 5

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'launchy', '~> 2.4'
   s.add_runtime_dependency 'retriable', '~> 1.4'
-  s.add_runtime_dependency 'activesupport', '>= 3.2', '< 5.0'
+  s.add_runtime_dependency 'activesupport', '>= 3.2'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'


### PR DESCRIPTION
### Problem:

Gem was not compatible with rails 5.4
### Solution:

Relaxing gem version dependency 
### Notes:

Check usage of gem with rails 5.4 and it works fine.
### QC Notes:

_TODO: What parts/flows of the app are affected by this change?_

### Release steps:

_TODO: steps needed for the release. If no special handling needed, please write 'Normal Release'_

### Security:

_TODO: Are the changes exposed publicly or internally?_

_TODO: Do all new endpoints impose proper access to authorized users only?_

### Network:

_TODO: Link to Ops PR if any. Type N/A if none._

_TODO: List new internal/external services communications that were introduced in this PR. Type N/A if none._


### Author checklist:
- [x] Backward compatibility checked
- [x] Release steps added
- [x] Unit tests added (if code logic is touched)
- [ ] JIRA ticket moved to Reviewing
- [x] Rebased to latest master
- [x] Commits are clean

### Reviewer checklist:
- [ ] Backward compatibility checked
- [ ] Code quality is acceptable
- [ ] Specs logic coverage
- [ ] Commits are clean
