### PR TITLE
[CRASHES-23954] upgrade faraday version

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'addressable', '~> 2.3'
   s.add_runtime_dependency 'signet', '~> 0.6'
-  s.add_runtime_dependency 'faraday', '~> 1.9.0'
+  s.add_runtime_dependency 'faraday', '~> 1.10'
   s.add_runtime_dependency 'faraday-multipart', '~> 1.0'
   s.add_runtime_dependency 'googleauth', '~> 0.3'
   s.add_runtime_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
### Problem:

Upgrading faraday version as we are forced to use this version for click_house gem to work with the new ruby version (3.3)

### Solution:

_TODO: how did you achieve it? what did you use?_

### Notes:

_TODO: anything that reviewers should know before reviewing?_

### QC Notes:

_TODO: What parts/flows of the app are affected by this change?_

### Release steps:

_TODO: steps needed for the release. If no special handling needed, please write 'Normal Release'_

### Security:

_TODO: Are the changes exposed publicly or internally?_

_TODO: Do all new endpoints impose proper access to authorized users only?_

### Network:

_TODO: Link to Ops PR if any. Type N/A if none._

_TODO: List new internal/external services communications that were introduced in this PR. Type N/A if none._


### Author checklist:
- [ ] Backward compatibility checked
- [ ] Release steps added
- [ ] Unit tests added (if code logic is touched)
- [ ] JIRA ticket moved to Reviewing
- [ ] Rebased to latest master
- [ ] Commits are clean

### Reviewer checklist:
- [ ] Backward compatibility checked
- [ ] Code quality is acceptable
- [ ] Specs logic coverage
- [ ] Commits are clean
